### PR TITLE
Add xapi video verbs

### DIFF
--- a/scripts/html5.js
+++ b/scripts/html5.js
@@ -211,7 +211,7 @@ H5P.VideoHtml5 = (function ($) {
               if (length > 0) {
                 // Length passed in as current time, because at end of video when this is fired currentTime reset to 0 if on loop
                 var progress = self.videoXAPI.getProgress(length, length);
-                if (progress >= 0.95) {
+                if (progress >= self.finishedThreshold) {
                   extraTrigger = 'finished';
                   extraArg = self.videoXAPI.getArgsXAPICompleted(video.currentTime, video.duration, progress);
                   lastSend = 'finished';

--- a/scripts/html5.js
+++ b/scripts/html5.js
@@ -13,12 +13,6 @@ H5P.VideoHtml5 = (function ($) {
     var self = this;
 
     /**
-     * xAPI Helper.
-     * @private
-     */
-    var videoXAPI = new H5P.VideoXAPI(self);
-
-    /**
      * Displayed when the video is buffering
      * @private
      */
@@ -162,7 +156,7 @@ H5P.VideoHtml5 = (function ($) {
         }
       }
 
-      return videoXAPI.getArgsXAPIInitialized(video.videoWidth, video.videoHeight, video.playbackRate, video.volume, ccEnabled, ccLanguage);
+      return self.videoXAPI.getArgsXAPIInitialized(video.videoWidth, video.videoHeight, video.playbackRate, video.volume, ccEnabled, ccLanguage);
 
     };
 
@@ -195,13 +189,13 @@ H5P.VideoHtml5 = (function ($) {
 
             if (arg === H5P.Video.PLAYING) {
               if (self.seeking === true) {
-                extraArg = videoXAPI.getArgsXAPISeeked(self.seekedTo);
+                extraArg = self.videoXAPI.getArgsXAPISeeked(self.seekedTo);
                 extraTrigger = 'seeked';
                 lastSend = 'seeked';
                 self.seeking = false;
               }
               else if (lastSend !== 'play') {
-                extraArg = videoXAPI.getArgsXAPIPlayed(video.currentTime);
+                extraArg = self.videoXAPI.getArgsXAPIPlayed(video.currentTime);
                 extraTrigger = 'play';
                 lastSend = 'play';
               }
@@ -211,7 +205,7 @@ H5P.VideoHtml5 = (function ($) {
               // Put together extraArg for sending to xAPI statement.
               if (!video.seeking && self.seeking === false && video.currentTime !== video.duration) {
                 extraTrigger = 'paused';
-                extraArg = videoXAPI.getArgsXAPIPaused(video.currentTime, video.duration);
+                extraArg = self.videoXAPI.getArgsXAPIPaused(video.currentTime, video.duration);
                 lastSend = 'paused';
               }
             }
@@ -221,10 +215,10 @@ H5P.VideoHtml5 = (function ($) {
               var length = video.duration;
               if (length > 0) {
                 // Length passed in as current time, because at end of video when this is fired currentTime reset to 0 if on loop
-                var progress = videoXAPI.getProgress(length, length);
+                var progress = self.videoXAPI.getProgress(length, length);
                 if (progress >= 0.95) {
                   extraTrigger = 'finished';
-                  extraArg = videoXAPI.getArgsXAPICompleted(video.currentTime, video.duration, progress);
+                  extraArg = self.videoXAPI.getArgsXAPICompleted(video.currentTime, video.duration, progress);
                   lastSend = 'finished';
                 }
               }
@@ -237,23 +231,23 @@ H5P.VideoHtml5 = (function ($) {
             return; // Just need to store current time for seeked event.
             break;
           case 'volumechange' :
-            arg = videoXAPI.getArgsXAPIVolumeChanged(video.currentTime, video.muted, video.volume);
+            arg = self.videoXAPI.getArgsXAPIVolumeChanged(video.currentTime, video.muted, video.volume);
             lastSend = 'volumechange';
             break;
           case 'play':
             if (self.seeking === false && lastSend !== h5p) {
-              arg = videoXAPI.getArgsXAPIPlayed(video.currentTime);
+              arg = self.videoXAPI.getArgsXAPIPlayed(video.currentTime);
               lastSend = h5p;
             }
             else {
-              arg = videoXAPI.getArgsXAPISeeked(self.seekedTo);
+              arg = self.videoXAPI.getArgsXAPISeeked(self.seekedTo);
               lastSend = 'seeked';
               self.seeking = false;
               h5p = 'seeked';
             }
             break;
           case 'fullscreen':
-            arg = videoXAPI.getArgsXAPIFullScreen(video.currentTime, video.videoWidth, video.videoHeight);
+            arg = self.videoXAPI.getArgsXAPIFullScreen(video.currentTime, video.videoWidth, video.videoHeight);
             lastSend = h5p;
             break;
           case 'loaded':

--- a/scripts/html5.js
+++ b/scripts/html5.js
@@ -1,5 +1,6 @@
 /** @namespace H5P */
 H5P.VideoHtml5 = (function ($) {
+  'use strict';
 
   /**
    * HTML5 video player for H5P.
@@ -283,7 +284,7 @@ H5P.VideoHtml5 = (function ($) {
               skipRateChange = false;
               return; // Avoid firing event when changing back
             }
-            if (H5P.Video.IE11_PLAYBACK_RATE_FIX && playbackRate != video.playbackRate) { // Intentional
+            if (H5P.Video.IE11_PLAYBACK_RATE_FIX && playbackRate !== video.playbackRate) { // Intentional
               // Prevent change in playback rate not triggered by the user
               video.playbackRate = playbackRate;
               skipRateChange = true;

--- a/scripts/html5.js
+++ b/scripts/html5.js
@@ -188,13 +188,7 @@ H5P.VideoHtml5 = (function ($) {
             }
 
             if (arg === H5P.Video.PLAYING) {
-              if (self.seeking === true) {
-                extraArg = self.videoXAPI.getArgsXAPISeeked(self.seekedTo);
-                extraTrigger = 'seeked';
-                lastSend = 'seeked';
-                self.seeking = false;
-              }
-              else if (lastSend !== 'play') {
+              if (lastSend !== 'play') {
                 extraArg = self.videoXAPI.getArgsXAPIPlayed(video.currentTime);
                 extraTrigger = 'play';
                 lastSend = 'play';
@@ -203,7 +197,7 @@ H5P.VideoHtml5 = (function ($) {
 
             if (arg === H5P.Video.PAUSED) {
               // Put together extraArg for sending to xAPI statement.
-              if (!video.seeking && self.seeking === false && video.currentTime !== video.duration) {
+              if (!video.seeking && self.seeking === false && video.currentTime !== video.duration && self.previousState !== H5P.Video.BUFFERING) {
                 extraTrigger = 'paused';
                 extraArg = self.videoXAPI.getArgsXAPIPaused(video.currentTime, video.duration);
                 lastSend = 'paused';
@@ -300,6 +294,7 @@ H5P.VideoHtml5 = (function ($) {
             arg = self.getPlaybackRate();
             break;
         }
+        self.previousState = arg;
         self.trigger(h5p, arg);
 
         // Make extra calls for events with needed values for xAPI statement.

--- a/scripts/video.js
+++ b/scripts/video.js
@@ -15,6 +15,8 @@ H5P.Video = (function ($, ContentCopyrights, MediaCopyright, handlers) {
   function Video(parameters, id) {
     var self = this;
 
+    self.videoXAPI = new H5P.VideoXAPI(self);
+
     // Ref youtube.js - ipad & youtube - issue
     self.pressToPlay = false;
 

--- a/scripts/video.js
+++ b/scripts/video.js
@@ -1,5 +1,6 @@
 /** @namespace H5P */
 H5P.Video = (function ($, ContentCopyrights, MediaCopyright, handlers) {
+  'use strict';
 
   /**
    * The ultimate H5P video player!

--- a/scripts/video.js
+++ b/scripts/video.js
@@ -20,11 +20,28 @@ H5P.Video = (function ($, ContentCopyrights, MediaCopyright, handlers) {
     // Ref youtube.js - ipad & youtube - issue
     self.pressToPlay = false;
 
-    // Values needed for xAPI triggering
+    // Values needed for xAPI triggering, set by handlers
     self.previousTime = 0;
     self.seeking = false;
     self.seekedTo = 0;
     self.duration = 0;
+    self.previousState = -1;
+    self.mousedown = false;
+
+    /*
+     * Used to distinguish seeking from pausing
+     * TODO: This might be much cleaner with refactoring IV, video and the handlers
+     */
+    document.addEventListener('mousedown', function() {
+      self.mousedown = true;
+    });
+    document.addEventListener('mouseup', function() {
+      if (self.seeking) {
+        self.trigger('seeked', self.videoXAPI.getArgsXAPISeeked(self.seekedTo));
+        self.seeking = false;
+      }
+      self.mousedown = false;
+    });
 
     // Initialize event inheritance
     H5P.EventDispatcher.call(self);
@@ -147,7 +164,10 @@ H5P.Video = (function ($, ContentCopyrights, MediaCopyright, handlers) {
       self.triggerXAPI('initialized', event.data);
     });
     self.on('paused', function (event) {
-      self.triggerXAPI('paused', event.data);
+      // if mouse button is down, we're seeking
+      if (self.mousedown === false) {
+        self.triggerXAPI('paused', event.data);
+      }
     });
 
     // Find player for video sources

--- a/scripts/video.js
+++ b/scripts/video.js
@@ -21,6 +21,8 @@ H5P.Video = (function ($, ContentCopyrights, MediaCopyright, handlers) {
     // Ref youtube.js - ipad & youtube - issue
     self.pressToPlay = false;
 
+    self.finishedThreshold = 0.95;
+
     // Values needed for xAPI triggering, set by handlers
     self.previousTime = 0;
     self.seeking = false;

--- a/scripts/x-api.js
+++ b/scripts/x-api.js
@@ -1,5 +1,6 @@
 /** @namespace H5P */
 H5P.VideoXAPI = (function ($) {
+  'use strict';
 
   /**
    * Xapi video statement generator for H5P.
@@ -425,7 +426,6 @@ H5P.VideoXAPI = (function ($) {
           }
         }
       }
-      xAPIBase = xAPIObject;
       return xAPIObject;
     };
   }

--- a/scripts/x-api.js
+++ b/scripts/x-api.js
@@ -135,7 +135,7 @@ H5P.VideoXAPI = (function ($) {
      */
     self.getArgsXAPIPlayed = function (currentTime) {
       var resultExtTime = formatFloat(currentTime);
-      playingSegmentStart = resultExtTime;
+      //playingSegmentStart = resultExtTime;
 
       return self.getArgsXAPI({
         verb: 'https://w3id.org/xapi/video/verbs/played',

--- a/scripts/youtube.js
+++ b/scripts/youtube.js
@@ -138,7 +138,7 @@ H5P.VideoYouTube = (function ($) {
                 if (length > 0) {
                   // Length passed in as current time, because at end of video when this is fired currentTime reset to 0 if on loop
                   var progress = self.videoXAPI.getProgress(length, length);
-                  if (progress >= 0.95) {
+                  if (progress >= self.finishedThreshold) {
                     var arg = self.videoXAPI.getArgsXAPICompleted(player.getCurrentTime(), self.duration, progress);
                     self.trigger('finished', arg);
                   }

--- a/scripts/youtube.js
+++ b/scripts/youtube.js
@@ -123,14 +123,10 @@ H5P.VideoYouTube = (function ($) {
                 if (self.seeking === false) {
                   self.trigger('play', self.videoXAPI.getArgsXAPIPlayed(player.getCurrentTime()));
                 }
-                else {
-                  self.trigger('seeked', self.videoXAPI.getArgsXAPISeeked(self.seekedTo));
-                  self.seeking = false;
-                }
               }
               else if (state.data === 2) {
                 // This is a paused event.
-                if (self.seeking === false) {
+                if (self.seeking === false && self.previousState !== 3) {
                   self.trigger('paused', self.videoXAPI.getArgsXAPIPaused(player.getCurrentTime(), self.duration));
                 }
               }
@@ -147,6 +143,7 @@ H5P.VideoYouTube = (function ($) {
                 }
               }
             }
+            self.previousState = state.data;
           },
           onPlaybackQualityChange: function (quality) {
             self.trigger('qualityChange', quality.data);

--- a/scripts/youtube.js
+++ b/scripts/youtube.js
@@ -1,5 +1,7 @@
 /** @namespace H5P */
+
 H5P.VideoYouTube = (function ($) {
+'use strict'
 
   /**
    * YouTube video player for H5P.
@@ -105,7 +107,7 @@ H5P.VideoYouTube = (function ($) {
             }
           },
           onStateChange: function (state) {
-            if (state.data > -1 && state.data < 4) {
+            if (state.data >= H5P.Video.ENDED && state.data <= H5P.Video.BUFFERING) {
 
               // Fix for keeping playback rate in IE11
               if (H5P.Video.IE11_PLAYBACK_RATE_FIX && state.data === H5P.Video.PLAYING && playbackRate !== 1) {
@@ -118,19 +120,19 @@ H5P.VideoYouTube = (function ($) {
               self.trigger('stateChange', state.data);
 
               // Calls for xAPI events.
-              if (state.data === 1) {
+              if (state.data === H5P.Video.PLAYING) {
                 // Get and send play call when not seeking.
                 if (self.seeking === false) {
                   self.trigger('play', self.videoXAPI.getArgsXAPIPlayed(player.getCurrentTime()));
                 }
               }
-              else if (state.data === 2) {
+              else if (state.data === H5P.Video.PAUSED) {
                 // This is a paused event.
-                if (self.seeking === false && self.previousState !== 3) {
+                if (self.seeking === false && self.previousState !== H5P.Video.BUFFERING) {
                   self.trigger('paused', self.videoXAPI.getArgsXAPIPaused(player.getCurrentTime(), self.duration));
                 }
               }
-              else if (state.data === 0) {
+              else if (state.data === H5P.Video.ENDED) {
                 // Send xapi trigger if video progress indicates finished.
                 var length = self.duration;
                 if (length > 0) {
@@ -214,7 +216,7 @@ H5P.VideoYouTube = (function ($) {
           break;
       }
 
-      return (returnType.toLowerCase().trim()=='width') ? width : height;
+      return (returnType.toLowerCase().trim() === 'width') ? width : height;
     };
 
     /**

--- a/scripts/youtube.js
+++ b/scripts/youtube.js
@@ -12,12 +12,6 @@ H5P.VideoYouTube = (function ($) {
   function YouTube(sources, options, l10n) {
     var self = this;
 
-    /**
-     * xAPI Helper.
-     * @private
-     */
-    var videoXAPI = new H5P.VideoXAPI(self);
-
     var player;
     var playbackRate = 1;
     var id = 'h5p-youtube-' + numInstances;
@@ -127,17 +121,17 @@ H5P.VideoYouTube = (function ($) {
               if (state.data === 1) {
                 // Get and send play call when not seeking.
                 if (self.seeking === false) {
-                  self.trigger('play', videoXAPI.getArgsXAPIPlayed(player.getCurrentTime()));
+                  self.trigger('play', self.videoXAPI.getArgsXAPIPlayed(player.getCurrentTime()));
                 }
                 else {
-                  self.trigger('seeked', videoXAPI.getArgsXAPISeeked(self.seekedTo));
+                  self.trigger('seeked', self.videoXAPI.getArgsXAPISeeked(self.seekedTo));
                   self.seeking = false;
                 }
               }
               else if (state.data === 2) {
                 // This is a paused event.
                 if (self.seeking === false) {
-                  self.trigger('paused', videoXAPI.getArgsXAPIPaused(player.getCurrentTime(), self.duration));
+                  self.trigger('paused', self.videoXAPI.getArgsXAPIPaused(player.getCurrentTime(), self.duration));
                 }
               }
               else if (state.data === 0) {
@@ -145,9 +139,9 @@ H5P.VideoYouTube = (function ($) {
                 var length = self.duration;
                 if (length > 0) {
                   // Length passed in as current time, because at end of video when this is fired currentTime reset to 0 if on loop
-                  var progress = videoXAPI.getProgress(length, length);
+                  var progress = self.videoXAPI.getProgress(length, length);
                   if (progress >= 0.95) {
-                    var arg = videoXAPI.getArgsXAPICompleted(player.getCurrentTime(), self.duration, progress);
+                    var arg = self.videoXAPI.getArgsXAPICompleted(player.getCurrentTime(), self.duration, progress);
                     self.trigger('finished', arg);
                   }
                 }
@@ -240,7 +234,7 @@ H5P.VideoYouTube = (function ($) {
         ccLanguage = player.getOptions('cc', 'track').languageCode;
       }
 
-      return videoXAPI.getArgsXAPIInitialized(width, height, self.getPlaybackRate(), self.getVolume(), ccEnabled, ccLanguage, self.getQuality());
+      return self.videoXAPI.getArgsXAPIInitialized(width, height, self.getPlaybackRate(), self.getVolume(), ccEnabled, ccLanguage, self.getQuality());
 
     };
 
@@ -420,7 +414,7 @@ H5P.VideoYouTube = (function ($) {
         return;
       }
 
-      self.trigger('volumechange', videoXAPI.getArgsXAPIVolumeChanged(player.getCurrentTime(), true, player.getVolume()));
+      self.trigger('volumechange', self.videoXAPI.getArgsXAPIVolumeChanged(player.getCurrentTime(), true, player.getVolume()));
 
       player.mute();
     };
@@ -435,7 +429,7 @@ H5P.VideoYouTube = (function ($) {
         return;
       }
 
-      self.trigger('volumechange', videoXAPI.getArgsXAPIVolumeChanged(player.getCurrentTime(), false, player.getVolume()));
+      self.trigger('volumechange', self.videoXAPI.getArgsXAPIVolumeChanged(player.getCurrentTime(), false, player.getVolume()));
 
       player.unMute();
     };
@@ -479,7 +473,7 @@ H5P.VideoYouTube = (function ($) {
         return;
       }
 
-      self.trigger('volumechange', videoXAPI.getArgsXAPIVolumeChanged(player.getCurrentTime(), player.isMuted(), level));
+      self.trigger('volumechange', self.videoXAPI.getArgsXAPIVolumeChanged(player.getCurrentTime(), player.isMuted(), level));
 
       player.setVolume(level);
     };


### PR DESCRIPTION
Hey all!

I just worked on the xAPI-verb integration. I'd appreciate a second opinion.

I got rid of the extra pause xAPI-statement before a seek xAPI-statement when the video is playing -- with the hacky mouse button listener that I suggested. That's not an ideal solution, but it works. Unfortunately, there's still a played xAPI-statement that's triggered after the seek xAPI-statement when the video is playing, and I have not yet found a way to get rid of it. It might be necessary to change Interactive Video as well (which would also be nice to get rid of the button listener). Maybe you have more luck? Do you see a way to trigger only "seeked" in both cases: video playing and user seeks/ video paused and user seeks?

I also got rid of the slight time deltas for the segments -- I think. It's caused by setting `playingSegmentStart` when building the xAPI statement for "played". It's slightly off the previous segment's end time (time between starting to play the video and getting the stateChange event that's listened to). Fortunately, it doesn't seem to be necessary unless I missed something (that's why I just uncommented the line). It will be set to the end of the previous segment on "pause" and "seek" -- which is exactly what's needed, and "seek" sets it the position that's seeked to. A progress of 100 % is possible now ;-)

After the Easter holidays, I'll discuss what we can do regarding changes to Interactive Video and the way H5P.Video does (or doesn't) handle its state -- if you neither see a way to get rid of the one played statement. Hardcoding the "finished" threshold should be fine for now (moved it to a variable), and could be made an option later. Please keep us posted about what the Video CoP decides on that issue.

Have a nice Easter Monday!

Best,
Oliver